### PR TITLE
Add error handling to C integration

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -13,7 +13,8 @@ fn main() {
 
     carp::on_up(my_up_callback);
     carp::on_down(my_down_callback);
-    carp::carp(config);
+
+    carp::carp(config).unwrap();
 }
 
 fn my_up_callback()

--- a/src/ucarp.c
+++ b/src/ucarp.c
@@ -121,9 +121,14 @@ void set_advskew(unsigned char _advskew)
     advskew = _advskew;
 }
 
-void set_dead_ratio(unsigned int _dead_ratio)
+int set_dead_ratio(unsigned int _dead_ratio)
 {
+    if (_dead_ratio <= 0U) {
+        logfile(LOG_ERR, "Dead ratio can't be zero");
+        return 1;
+    }
     dead_ratio = _dead_ratio;
+    return 0;
 }
 
 void set_preempt(signed char _preempt)
@@ -207,10 +212,6 @@ int libmain(struct Config *config)
     }
     if (down_callback == NULL) {
         logfile(LOG_WARNING, "Warning: no callback registered when going down");
-    }
-    if (dead_ratio <= 0U) {
-        logfile(LOG_ERR, "Dead ratio can't be zero");
-        return 1;
     }
     init_rand();
     if (docarp() != 0) {


### PR DESCRIPTION
The Rust code will now properly handle errors when calling the carp C
functions. This is exposed as a `CarpError` that the caller can handle
however they see fit.
