### PR TITLE
Add a module to get the MAC address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,8 @@ name = "carp"
 version = "0.1.0"
 dependencies = [
  "gcc 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -15,12 +17,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "gcc"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "nix"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ authors = ["Herman J. Radtke III <herman@hermanradtke.com>"]
 build = "build.rs"
 
 [dependencies]
+libc = "0.2.7"
+nix = "0.4.2"
 
 [build-dependencies]
 gcc = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,10 +19,17 @@
 // This should become stable in 1.7
 #![feature(ip_addr)]
 
+extern crate libc;
+
+#[cfg(unix)]
+extern crate nix;
+
 use std::net::IpAddr;
 use std::os::raw::{c_char, c_uchar, c_uint};
 use std::str::FromStr;
 use std::fmt;
+
+mod mac;
 
 ///
 /// Configuration options for CARP

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -1,0 +1,78 @@
+use std::os::raw::{c_int, c_char, c_ulong};
+use std::os::unix::io::{RawFd};
+use std::mem;
+use libc::sockaddr;
+use std::io::{self, Error, ErrorKind};
+use nix::sys::socket::{socket, SockType, SockFlag, AddressFamily};
+
+// TODO test this across other OSes
+const SIOCGIFHWADDR: c_ulong = 0x00008927;
+
+#[repr(C)]
+struct IfReq {
+    ifr_name: [c_char; 16],
+    ifr_hwaddr: sockaddr,
+    _padding: [u8; 8],
+}
+
+extern {
+    fn ioctl(fd: c_int, request: c_ulong, ifreq: *mut IfReq) -> c_int;
+}
+
+#[derive(Debug)]
+pub struct HwAddr(String);
+
+///
+/// Get Hardware (MAC) address for a given network interface
+///
+/// The response looks something like: HwAddr("08:00:27:4d:3c:39")
+///
+pub fn hw_addr(if_name: &str) -> io::Result<HwAddr> {
+
+    let fd = try!(socket(
+        AddressFamily::Inet,
+        SockType::Datagram,
+        SockFlag::empty()
+    ));
+
+    let mut req: Box<IfReq> = Box::new(unsafe { mem::zeroed() });
+
+    if if_name.len() >= req.ifr_name.len() {
+        return Err(Error::new(ErrorKind::Other, "Interface name too long"));
+    }
+
+    // basically a memcpy
+    for (a, c) in req.ifr_name.iter_mut().zip(if_name.bytes()) {
+        *a = c as i8;
+    }
+
+    if unsafe { ioctl(fd, SIOCGIFHWADDR, &mut *req) } == -1 {
+        return Err(Error::last_os_error());
+    }
+
+    let mac = format!(
+        "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+        req.ifr_hwaddr.sa_data[0],
+        req.ifr_hwaddr.sa_data[1],
+        req.ifr_hwaddr.sa_data[2],
+        req.ifr_hwaddr.sa_data[3],
+        req.ifr_hwaddr.sa_data[4],
+        req.ifr_hwaddr.sa_data[5],
+    );
+
+    Ok(HwAddr(mac))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hw_addr() {
+        // TODO dynamically get interface
+        assert_eq!(17, hw_addr("eth0").unwrap().0.len());
+        assert!(hw_addr("nope").is_err());
+        assert!(hw_addr("waytoolonginterface").is_err());
+        assert!(hw_addr("1234567890123456").is_err());
+    }
+}


### PR DESCRIPTION
Replaces src/fillmac.{c,h} with a Rust alternative. Right now this
returns a type that is basically a string. This will almost surely
change when I implement Gratuitous ARP.
