### PR TITLE
Get integration tests working on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,12 @@ language: rust
 
 rust:
   - nightly
-    #  - beta
-    #  - stable
+  - beta
+  - stable
 
-matrix:
-  allow_failures:
-    - rust: stable
-    - rust: beta
+cache: cargo
 
 before_script:
-  - ifconfig -a
-  - sh ./ip.sh
   - sudo apt-get -qq update
   - sudo apt-get -y install libpcap-dev sqlite3 libsqlite3-dev
 # See https://github.com/travis-ci/travis-ci/issues/1350
@@ -23,4 +18,4 @@ before_script:
 
 script:
   - cargo build --verbose
-  - sudo RUST_LOG=carp RUST_BACKTRACE=1 cargo test --verbose -- --nocapture
+  - sudo TEST_INF=eth0 TEST_SRCIP=$(sh ./ip.sh) RUST_LOG=carp RUST_BACKTRACE=1 cargo test --verbose -- --nocapture


### PR DESCRIPTION
Each travis run has a different IP address, so we need a way to capture
that value. I decided to be pragmatic and set env vars to configure the
integration tests.
