### PR TITLE
Harden the advertisement code

### DIFF
--- a/src/arp.rs
+++ b/src/arp.rs
@@ -187,7 +187,6 @@ pub fn gratuitous_arp(if_name: &str, ip: Ipv4Addr) -> io::Result<()> {
             match err.kind() {
                 ErrorKind::Interrupted => {}
                 _ => {
-                    println!("err = {}", err);
                     return Err(err);
                 }
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,8 @@
 use std::io;
 use std::fmt;
 
+use byteorder;
+use nix;
 use pcap;
 
 #[derive(Debug)]
@@ -33,6 +35,8 @@ pub enum Error {
     CarpFailure,
     Pcap(pcap::Error),
     Io(io::Error),
+    ByteOrder(byteorder::Error),
+    Nix(nix::Error),
 }
 
 impl fmt::Display for Error {
@@ -51,6 +55,8 @@ impl fmt::Display for Error {
             CarpFailure => write!(fmt, "CarpFailure"),
             Pcap(ref err) => write!(fmt, "{}", err),
             Io(ref err) => write!(fmt, "{}", err),
+            ByteOrder(ref err) => write!(fmt, "{}", err),
+            Nix(ref err) => write!(fmt, "{}", err),
         }
     }
 }
@@ -64,5 +70,17 @@ impl From<pcap::Error> for Error {
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Self {
         Error::Io(err)
+    }
+}
+
+impl From<byteorder::Error> for Error {
+    fn from(err: byteorder::Error) -> Self {
+        Error::ByteOrder(err)
+    }
+}
+
+impl From<nix::Error> for Error {
+    fn from(err: nix::Error) -> Self {
+        Error::Nix(err)
     }
 }


### PR DESCRIPTION
- remove unwraps from `send_advert()` function body
- handle interrupts when trying to write advert to socket
- log appropriately when advert fails

There is still the outstanding issue of doing some tracking of
advertisement failures. The original UCarp code is doing this, but it is
not clear from reading the code what the point is. There is some
handling of a flag `carp_suppress_preempt` and there is a a call to
`carp_send_ad_all()` when some max error count is hit. The
`carp_send_ad_all` function does not do anything except call
`carp_send_ad()` again though. This all looks incomplete.

Failed advertisements should be handled by the remote backup node's
timeout logic. The only danger I can see is that the existing primary
starts failing to send advertisements, but continues to think it is the
primary node. This would mean two nodes are primary. The node that
becomes primary last will issue the arp and try to take over the shared
VIP. However, if we have a network partition then the arp might never
make it to the entire network. There is some more to think about when it
comes to handling advertisement errors.
