### PR TITLE
Make some modules private

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -31,6 +31,7 @@ fn main() {
     config.set_interface(if_name.as_ref());
     config.set_advbase(1);
     config.set_advskew(1);
+    config.set_preempt(true);
 
     let capture = carp::carp::Carp::default_pcap(&if_name).unwrap();
     let mut carp = carp::carp::Carp::new(config, capture);

--- a/run.sh
+++ b/run.sh
@@ -9,9 +9,9 @@ tmux bind-key -n Escape kill-session
 tmux new-window -t $SESSION:1 -n 'CARP'
 tmux split-window -v
 tmux select-pane -t 0
-tmux send-keys "sudo /vagrant/target/debug/examples/basic -i eth1 -s 10.0.2.30" C-m
+tmux send-keys "sh /vagrant/ucarp.sh" C-m
 tmux select-pane -t 1
-tmux send-keys "sudo RUST_LOG=trace /vagrant/target/debug/examples/pure -i eth1 -s 10.0.2.40" C-m
+tmux send-keys "sleep 10 && sudo RUST_LOG=trace /vagrant/target/debug/examples/basic -i eth2 -s 10.0.2.40" C-m
 
 # Attach to session
 tmux -2 attach-session -t $SESSION

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,7 +117,7 @@ impl Config {
             vhid: 1,
             password: password.into(),
             advbase: 1,
-            advskew: 1,
+            advskew: 0,
             dead_ratio: 3,
             interface: None,
             mcast: FromStr::from_str("224.0.0.18").unwrap(),
@@ -147,5 +147,9 @@ impl Config {
 
     pub fn set_advskew(&mut self, advskew: u8) {
         self.advskew = advskew;
+    }
+
+    pub fn set_preempt(&mut self, preempt: bool) {
+        self.preempt = preempt;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,11 +32,11 @@ use std::result;
 
 pub mod net;
 
-pub mod config;
-pub mod ip_carp;
-pub mod error;
+mod error;
+mod node;
 pub mod advert;
+pub mod ip_carp;
+pub mod config;
 pub mod carp;
-pub mod node;
 
 pub type Result<T> = result::Result<T, error::Error>;

--- a/src/node.rs
+++ b/src/node.rs
@@ -87,8 +87,8 @@ impl PartialOrd for Node {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         if self.adv_freq == other.adv_freq {
             Some(match self.ip.cmp(&other.ip) {
-                Ordering::Less => Ordering::Greater,
-                Ordering::Greater => Ordering::Less,
+                Ordering::Less => Ordering::Less,
+                Ordering::Greater => Ordering::Greater,
                 Ordering::Equal => Ordering::Less,
             })
 
@@ -112,7 +112,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_primary_to_backup() {
+    fn test_primary_role_change() {
         let node = Node::new(Role::Primary,
                              Duration::from_secs(2),
                              "10.0.0.2".parse().unwrap());
@@ -124,25 +124,25 @@ mod tests {
 
         let node = Node::new(Role::Primary,
                              Duration::from_secs(1),
-                             "10.0.0.2".parse().unwrap());
-        let other = Node::new(Role::Primary,
-                              Duration::from_secs(1),
-                              "10.0.0.1".parse().unwrap());
-
-        assert_eq!(Role::Primary, node.role_change(&other, Alignment::Passive));
-
-        let node = Node::new(Role::Primary,
-                             Duration::from_secs(1),
                              "10.0.0.1".parse().unwrap());
         let other = Node::new(Role::Primary,
                               Duration::from_secs(1),
                               "10.0.0.2".parse().unwrap());
 
+        assert_eq!(Role::Primary, node.role_change(&other, Alignment::Passive));
+
+        let node = Node::new(Role::Primary,
+                             Duration::from_secs(1),
+                             "10.0.0.2".parse().unwrap());
+        let other = Node::new(Role::Primary,
+                              Duration::from_secs(1),
+                              "10.0.0.1".parse().unwrap());
+
         assert_eq!(Role::Backup, node.role_change(&other, Alignment::Passive));
     }
 
     #[test]
-    fn test_backup_to_primary() {
+    fn test_backup_role_change() {
         let node = Node::new(Role::Backup,
                              Duration::from_secs(1),
                              "10.0.0.1".parse().unwrap());
@@ -155,17 +155,14 @@ mod tests {
 
         let node = Node::new(Role::Backup,
                              Duration::from_secs(1),
-                             "10.0.0.2".parse().unwrap());
+                             "10.0.0.1".parse().unwrap());
         let other = Node::new(Role::Backup,
                               Duration::from_secs(1),
-                              "10.0.0.1".parse().unwrap());
+                              "10.0.0.2".parse().unwrap());
 
         assert_eq!(Role::Primary,
                    node.role_change(&other, Alignment::Aggressive));
-    }
 
-    #[test]
-    fn test_backup_non_aggressive() {
         let node = Node::new(Role::Backup,
                              Duration::from_secs(1),
                              "10.0.0.1".parse().unwrap());
@@ -194,7 +191,7 @@ mod tests {
                               Duration::from_secs(1),
                               "10.0.0.1".parse().unwrap());
         let given = node.cmp(&other);
-        assert_eq!(Ordering::Less, given);
+        assert_eq!(Ordering::Greater, given);
     }
 
     #[test]
@@ -215,6 +212,6 @@ mod tests {
                               Duration::from_secs(1),
                               "10.0.0.2".parse().unwrap());
         let given = node.cmp(&other);
-        assert_eq!(Ordering::Greater, given);
+        assert_eq!(Ordering::Less, given);
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -34,6 +34,7 @@ fn setup(advbase: u8) -> Carp {
     config.set_interface(interface.as_ref());
     config.set_advbase(advbase);
     config.set_advskew(0);
+    config.set_preempt(true);
     let capture = carp::carp::Carp::default_pcap(&interface).unwrap();
     let mut carp = carp::carp::Carp::new(config, capture);
     carp.setup().unwrap();
@@ -94,7 +95,6 @@ fn test_role_change_primary_on_timeout() {
 
 #[test]
 fn test_role_change_backup_if_larger_advert_base() {
-    env_logger::init().ok().expect("Failed to init logger");
     let cp = CarpPacket::new(
         setup_ether_header(),
         setup_ipv4_header("10.0.0.2"),
@@ -126,10 +126,10 @@ fn test_role_change_primary_if_shorter_advert_base() {
 }
 
 #[test]
-fn test_role_change_backup_if_equal_advbase_lower_ip() {
+fn test_role_change_backup_if_equal_advbase_higher_ip() {
     let cp = CarpPacket::new(
         setup_ether_header(),
-        setup_ipv4_header("10.244.244.244"),
+        setup_ipv4_header("10.0.0.2"),
         setup_carp_header(1)
     );
 
@@ -145,10 +145,11 @@ fn test_role_change_backup_if_equal_advbase_lower_ip() {
 }
 
 #[test]
-fn test_role_stay_primary_if_equal_advbase_higher_ip() {
+fn test_role_stay_primary_if_equal_advbase_lower_ip() {
+    //env_logger::init().ok().expect("Failed to init logger");
     let cp = CarpPacket::new(
         setup_ether_header(),
-        setup_ipv4_header("10.0.0.2"),
+        setup_ipv4_header("10.244.244.244"),
         setup_carp_header(1)
     );
 

--- a/ucarp.sh
+++ b/ucarp.sh
@@ -2,7 +2,7 @@
 
 DIR=/home/vagrant/UCarp
 
-sudo $DIR/src/ucarp --interface=eth3 --srcip=10.0.2.30 --vhid=1 \
+sudo $DIR/src/ucarp --interface=eth1 --srcip=10.0.2.30 --vhid=1 \
       --pass=secret --addr=10.0.2.100 --advbase=3 \
       --upscript=$DIR/examples/linux/vip-up.sh \
       --downscript=$DIR/examples/linux/vip-down.sh


### PR DESCRIPTION
Turning some modules private caused me to realize that I had a bug in
the way node were being compared and the way advertisement frequency was
being calculated. This appears to be handled correctly now.
